### PR TITLE
Remove repeated l/fst

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -339,7 +339,7 @@ transducers. Let see a example:
 
 [source, clojure]
 ----
-(def my-lens (comp l/fst l/fst (l/nth 2)))
+(def my-lens (comp l/fst (l/nth 2)))
 
 (def data
   [[0 1 2]


### PR DESCRIPTION
The supplied example of composition doesn't work with the supplied data. To make it work I've removed one of the `l/fst`.

```
The author or authors of this code dedicate any and all copyright interest
in this code to the public domain. We make this dedication for the benefit of
the public at large and to the detriment of our heirs and successors. We
intend this dedication to be an overt act of relinquishment in perpetuity of
all present and future rights to this code under copyright law.
```