### PR TITLE
Atomic swap and IAtom2 implementation

### DIFF
--- a/src/lentes/core.cljc
+++ b/src/lentes/core.cljc
@@ -166,20 +166,15 @@
 
      clojure.lang.IAtom
      (reset [self newval]
-       (swap! src #(put lens newval %))
-       (deref self))
+       (focus lens (swap! src #(put lens newval %))))
      (swap [self f]
-       (swap! src (fn [s] (over lens f s)))
-       (deref self))
+       (focus lens (swap! src (fn [s] (over lens f s)))))
      (swap [self f x]
-       (swap! src (fn [s] (over lens #(f % x) s)))
-       (deref self))
+       (focus lens (swap! src (fn [s] (over lens #(f % x) s)))))
      (swap [self f x y]
-       (swap! src (fn [s] (over lens #(f % x y) s)))
-       (deref self))
+       (focus lens (swap! src (fn [s] (over lens #(f % x y) s)))))
      (swap [self f x y more]
-       (swap! src (fn [s] (over lens #(apply f % x y more) s)))
-       (deref self))
+       (focus lens (swap! src (fn [s] (over lens #(apply f % x y more) s)))))
 
      clojure.lang.IRef
      (addWatch [self key cb]

--- a/src/lentes/core.cljc
+++ b/src/lentes/core.cljc
@@ -176,6 +176,18 @@
      (swap [self f x y more]
        (focus lens (swap! src (fn [s] (over lens #(apply f % x y more) s)))))
 
+     clojure.lang.IAtom2
+     (resetVals [self newval]
+       (mapv (partial focus lens) (swap-vals! src #(put lens newval %))))
+     (swapVals [self f]
+       (mapv (partial focus lens) (swap-vals! src (fn [s] (over lens f s)))))
+     (swapVals [self f x]
+       (mapv (partial focus lens) (swap-vals! src (fn [s] (over lens #(f % x) s)))))
+     (swapVals [self f x y]
+       (mapv (partial focus lens) (swap-vals! src (fn [s] (over lens #(f % x y) s)))))
+     (swapVals [self f x y more]
+       (mapv (partial focus lens) (swap-vals! src (fn [s] (over lens #(apply f % x y more) s)))))
+
      clojure.lang.IRef
      (addWatch [self key cb]
        (locking self

--- a/test/lentes/tests.cljc
+++ b/test/lentes/tests.cljc
@@ -224,6 +224,7 @@
     (t/is (= @fsource 0))
 
     #?@(:clj  [(t/is (instance? clojure.lang.IAtom fsource))
+               (t/is (instance? clojure.lang.IAtom2 fsource))
                (t/is (instance? clojure.lang.IDeref fsource))
                (t/is (instance? clojure.lang.IRef fsource))]
         :cljs [(t/is (satisfies? IDeref fsource))
@@ -245,6 +246,7 @@
     (t/is (= @fsource 0))
 
     #?@(:clj  [(t/is (not (instance? clojure.lang.IAtom fsource)))
+               (t/is (not (instance? clojure.lang.IAtom2 fsource)))
                (t/is (instance? clojure.lang.IDeref fsource))
                (t/is (instance? clojure.lang.IRef fsource))]
         :cljs [(t/is (satisfies? IDeref fsource))


### PR DESCRIPTION
Thank you for sharing this useful library!
Although it might be very rare, `deref`ing after the `swap!` could lead to a different value than what we produced in the call to `swap!`. 

I also took the liberty to implement the `clojure.lang.IAtom2` interface, as lentes already depends on a recent-enough clojure that supports working with this interface.

Please let me know where and how to add some improvements, tests and/or documentation to get this merged